### PR TITLE
Add imaging scrape support

### DIFF
--- a/scrapers/Coomer/SHALookup/SHALookup.py
+++ b/scrapers/Coomer/SHALookup/SHALookup.py
@@ -112,7 +112,6 @@ def getPostByHash(hash):
     scene = postres.json()
     scene = scene["post"]
     return splitLookup(scene, hash)
-    return splitLookup(scene, hash)
 
 def splitLookup(scene, hash):
     if (scene['service'] == "fansly"):

--- a/scrapers/Coomer/SHALookup/SHALookup.yml
+++ b/scrapers/Coomer/SHALookup/SHALookup.yml
@@ -6,6 +6,13 @@ sceneByFragment:
       # use python3 instead if needed
       - SHALookup.py
       - query
+imageByFragment:
+    action: script
+    script:
+      - python
+      # use python3 instead if needed
+      - SHALookup.py
+      - query
 
 # Originally hosted at: https://github.com/feederbox826/FansDB-SHALookup
 # Last Updated 2025-01-01


### PR DESCRIPTION
This resolves #3 

- Adds the ability to use current functions to look up SHA of images
- Replaces result URL with URLs as it is deprecated
- Images will be numbered separately from scenes:  <part>/<total videos>and <part>/<total images> pics
  - This will prevent any title changes of existing scraped content
 